### PR TITLE
Fix api request compression

### DIFF
--- a/plugin.program.deluge/resources/lib/DelugeWebUIJson.py
+++ b/plugin.program.deluge/resources/lib/DelugeWebUIJson.py
@@ -20,6 +20,7 @@ class DelugeWebUIJson(object):
         json_dict = {'method':methodName,'params':params,'id':jsonid}
         data = json.dumps(json_dict)
         req = urllib2.Request(self.url, data, {'Content-Type': 'application/json'})
+        req.add_header('Accept-encoding', 'gzip')
         if cookie is not None :
             req.add_header('cookie', cookie)
         res = urllib2.urlopen(req)

--- a/plugin.program.deluge/resources/lib/DelugeWebUIJson.py
+++ b/plugin.program.deluge/resources/lib/DelugeWebUIJson.py
@@ -29,7 +29,7 @@ class DelugeWebUIJson(object):
         res.close()
         if encoding == 'gzip' :
             return unGzip(content)
-        return None
+        return content
     
     def getJsonId(self):
         self.jsonid += 1


### PR DESCRIPTION
API requests didn't request compressed responses but expected to receive compressed responses only.

- Support uncompressed responses
- Explicitly request compressed responses